### PR TITLE
Fix #15 - Look for TODO in the right place

### DIFF
--- a/lib/Test/Mocha/CalledOk.pm
+++ b/lib/Test/Mocha/CalledOk.pm
@@ -21,8 +21,10 @@ sub test {
     $test_name = "$method_call was called $exp_times" if !defined $test_name;
 
     # Test failure report should not trace back to Mocha modules
-    local $Test::Builder::Level = $Test::Builder::Level + 1;
-    $TB->ok( $test_ok, $test_name );
+    {
+        local $Test::Builder::Level = $Test::Builder::Level + 1;
+        $TB->ok( $test_ok, $test_name );
+    }
 
     # output diagnostics to aid with debugging
     unless ( $test_ok || $TB->in_todo ) {

--- a/t/called_ok.t
+++ b/t/called_ok.t
@@ -365,16 +365,12 @@ ERR
 
     subtest 'called_ok() in a TODO block' => sub {
         my $test_name = 'test_method() was called 1 time(s)';
-        my $line      = __LINE__ + 14;
+        my $line      = __LINE__ + 10;
 
         chomp( my $out = <<"OUT" );
 not ok 1 - $test_name # TODO should fail
     #   Failed (TODO) test '$test_name'
     #   at $FILE line $line.
-    # Error: unexpected number of calls to 'test_method()'
-    #          got: 0 time(s)
-    #     expected: 1 time(s)
-$diag_call_history
 OUT
         test_out($out);
       TODO: {


### PR DESCRIPTION
In CalledOk '$Test::Builder::Level' is altered before calling ok(). This
is not itself a problem, the problem is that the alteration is not
restored before calling $TB->TODO, as such it is looking for TODO in the
wrong place.

The test to ensure the diagnostics don't show up was incorrect and
checked that they do show up. These 2 errors together resulted in a test
passing when it should nto have.

This was discovered with an upcoming Test::More dev release. With this
path the tests pass on both new and old versions.