### PR TITLE
Pass spy when dispatching to real object method

### DIFF
--- a/t/lib/TestClass.pm
+++ b/t/lib/TestClass.pm
@@ -26,4 +26,10 @@ sub once   { }
 sub twice  { }
 sub thrice { }
 
+sub direct {
+    my $self = shift;
+    $self->indirect
+}
+sub indirect { 'indirect' }
+
 1;

--- a/t/spy.t
+++ b/t/spy.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 19;
+use Test::More tests => 20;
 use Test::Fatal;
 #use Scalar::Util qw( blessed );
 
@@ -71,6 +71,18 @@ subtest 'spy does not can(any_method)' => sub {
         $spy->__calls->[-1]->stringify_long,
         qq{can("foo") called at $FILE line $line},
         '... and method call is recorded'
+    );
+};
+
+# ----------------------
+# spy is passed to real object's methods
+
+subtest 'spy invokes a stubbed method indirectly' => sub {
+    stub { $spy->indirect } returns('stubbed indirect');
+    is(
+        $spy->direct,
+        'stubbed indirect',
+        '... and invokes the method'
     );
 };
 


### PR DESCRIPTION
This PR addresses a limitation of using spies. Consider creating a spy on an object with method `a` that in turn invokes method `b`, and you stub method `b`. If you invoke method `a` as `$spy->a`, the stubbed method `b` is not called. This is because the method is dispatched directly on the original object and the spy is not passed through.

This change modifies the method dispatch logic to pass the spy through in all cases except for `isa` and `DOES`, which continue to be handled directly by the original object.