### PR TITLE
Delegate hash access on spy to the real object

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -25,6 +25,7 @@ finder = PublicModules
 
 [AutoPrereqs]
 skips = ^Moose
+skip = ^Tie::ExtraHash$
 [OptionalFeature / AuthorTests]
 -description = Modules required for author tests
 -phase       = develop

--- a/lib/Test/Mocha.pm
+++ b/lib/Test/Mocha.pm
@@ -500,7 +500,7 @@ sub inspect_all ($) {
     croak 'inspect_all() must be given a mock or spy object'
       if !$mock->isa('Test::Mocha::SpyBase');
 
-    return @{ $mock->{calls} };
+    return @{ $mock->__calls };
 }
 
 =func clear

--- a/lib/Test/Mocha/SpyBase.pm
+++ b/lib/Test/Mocha/SpyBase.pm
@@ -33,12 +33,14 @@ sub __new {
 
 sub __calls {
     my ($self) = @_;
-    return $self->{calls};
+    my $args = tied(%{$self}) ? tied(%{$self})->[1] : $self;
+    return $args->{calls};
 }
 
 sub __stubs {
     my ($self) = @_;
-    return $self->{stubs};
+    my $args = tied(%{$self}) ? tied(%{$self})->[1] : $self;
+    return $args->{stubs};
 }
 
 sub __find_stub {

--- a/lib/Test/Mocha/SpyHash.pm
+++ b/lib/Test/Mocha/SpyHash.pm
@@ -1,0 +1,19 @@
+package Test::Mocha::SpyHash;
+# tied hash support for spy
+
+use strict;
+use warnings;
+
+use Tie::Hash ();
+
+use parent -norequire, 'Tie::ExtraHash';
+
+# pass spy attributes hashref. the tied hash will access the real object.
+# access the the spy attributes is available through tied(%$spy)->[1].
+sub TIEHASH
+{
+    my ($class, $args) = @_;
+    return bless[$args->{object}, $args], $class;
+}
+
+1;

--- a/lib/Test/Mocha/SpyHash.pm
+++ b/lib/Test/Mocha/SpyHash.pm
@@ -9,7 +9,7 @@ use Tie::Hash ();
 use parent -norequire, 'Tie::ExtraHash';
 
 # pass spy attributes hashref. the tied hash will access the real object.
-# access the the spy attributes is available through tied(%$spy)->[1].
+# access to the spy attributes is available through tied(%$spy)->[1].
 sub TIEHASH
 {
     my ($class, $args) = @_;

--- a/t/spy.t
+++ b/t/spy.t
@@ -87,8 +87,8 @@ subtest 'spy accesses the real object hash' => sub {
     );
     $spy->{bar} = 'BAR';
     is(
-        'FOO',
-        $obj->{foo},
+        'BAR',
+        $obj->{bar},
         '...for storing values',
     );
     is_deeply(

--- a/t/spy.t
+++ b/t/spy.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 20;
+use Test::More tests => 21;
 use Test::Fatal;
 #use Scalar::Util qw( blessed );
 
@@ -22,10 +22,10 @@ my $spy = spy($obj);
 ok( $spy, 'spy($obj) creates a simple spy' );
 is( $spy->__object, $obj, 'spy wraps object' );
 
-subtest 'spy() must be given a blessed object' => sub {
+subtest 'spy() must be given a blessed HASH reference' => sub {
     like(
         my $e = exception { spy(1) },
-        qr{^Can't spy on an unblessed reference},
+        qr{^Can only spy on a blessed HASH reference},
         'error is thrown'
     );
     like( $e, qr{at \Q$FILE\E}, '... and error traces back to this file' );
@@ -71,6 +71,30 @@ subtest 'spy does not can(any_method)' => sub {
         $spy->__calls->[-1]->stringify_long,
         qq{can("foo") called at $FILE line $line},
         '... and method call is recorded'
+    );
+};
+
+
+# ----------------------
+# spy delegates hash access to the real object
+
+subtest 'spy accesses the real object hash' => sub {
+    $obj->{foo} = 'FOO';
+    is(
+        'FOO',
+        $spy->{foo},
+        '...for fetching values',
+    );
+    $spy->{bar} = 'BAR';
+    is(
+        'FOO',
+        $obj->{foo},
+        '...for storing values',
+    );
+    is_deeply(
+        ['bar', 'foo'],
+        [sort keys %$spy],
+        '...for retrieving keys',
     );
 };
 


### PR DESCRIPTION
The commit at 2bd4439 to pass the spy to method calls works great for method dispatch, but breaks direct access to the blessed object (hash reference).

For example, the following fails under 0.65:

```perl
{
    package MyClass;
    sub new { bless { foo => 'FOO' }, shift }
    sub say_foo { my $self = shift; print $self->{foo}, "\n" }
}

use Test::Mocha;
my $obj = MyClass->new;
my $spy = spy($obj);
$spy->say_foo;     # should print "FOO"
```

Instead of printing 'FOO', the last line prints nothing (undef), because in `sub say_foo`, `$self->{foo}` is accessing the `foo` element of the spy object instead of the real object.

This PR converts the spy to a tied hash (using the core `Tie::ExtraHash` module) so that direct hash operations are delegated to the real object.

The spy's attributes can be access through `tied($spy)->[1]`. This technique is applied in the `__object`, `__calls`, and `__stubs` methods.

As a limitation, `spy()` only accepts blessed HASH references. That probably covers the vast majority of use cases. Support for blessed SCALAR and ARRAY references can be added fairly easily.